### PR TITLE
allow placeholder mixin to be used at root level

### DIFF
--- a/source/javascripts/frob_core_helpers.js
+++ b/source/javascripts/frob_core_helpers.js
@@ -127,7 +127,7 @@ var FCH = {
   /**
   * @function hasClass Determine if element has class with vanilla JS
   * @param {object} el
-  * @parma {string} cls
+  * @param {string} cls
   * @source http://jaketrent.com/post/addremove-classes-raw-javascript/
   */
   hasClass: function(el, cls) {
@@ -137,7 +137,7 @@ var FCH = {
   /**
   * @function addClass Add class to element with vanilla JS
   * @param {object} el
-  * @parma {string} cls
+  * @param {string} cls
   * @source http://jaketrent.com/post/addremove-classes-raw-javascript/
   */
   addClass: function(el, cls) {
@@ -149,7 +149,7 @@ var FCH = {
   /**
   * @function removeClass Remove class from element with vanilla JS
   * @param {object} el
-  * @parma {string} cls
+  * @param {string} cls
   * @source http://jaketrent.com/post/addremove-classes-raw-javascript/
   */
   removeClass: function(el, cls) {
@@ -254,7 +254,7 @@ var FCH = {
     });
   },
 
-}
+};
 
 /* Cached jQuery variables */
 if(typeof jQuery !== 'undefined') {

--- a/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
+++ b/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
@@ -226,6 +226,10 @@
       @content;
     }
 
+    :-ms-input-placeholder {
+      @content;
+    }
+
   }
 }
 

--- a/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
+++ b/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
@@ -199,10 +199,6 @@
       @content;
     }
 
-    &:-moz-placeholder {
-      @content;
-    }
-
     &::-moz-placeholder {
       @content;
     }
@@ -219,6 +215,10 @@
     }
 
     ::-moz-placeholder {
+      @content;
+    }
+
+    :-moz-placeholder {
       @content;
     }
 

--- a/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
+++ b/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
@@ -190,33 +190,42 @@
   }
 }
 
-// Taken
-// from
-// Bourbon
-$placeholders: '-webkit-input-placeholder',
-               '-moz-placeholder',
-               '-ms-input-placeholder';
-
+// Style placeholder text at the root level or on an element
 @mixin placeholder {
-  @each $placeholder in $placeholders {
-    @if $placeholder == '-webkit-input-placeholder' {
-      &::#{$placeholder} {
-        @content;
-      }
-    } @else if $placeholder == '-moz-placeholder' {
-      // FF 18-
-      &:#{$placeholder} {
-        @content;
-      }
-      // FF 19+
-      &::#{$placeholder} {
-        @content;
-      }
-    } @else {
-      &:#{$placeholder} {
-        @content;
-      }
+
+  @if & {
+
+    &::-webkit-input-placeholder {
+      @content;
     }
+
+    &:-moz-placeholder {
+      @content;
+    }
+
+    ::-moz-placeholder {
+      @content;
+    }
+
+    &:-ms-input-placeholder {
+      @content;
+    }
+
+  } @else {
+
+    input[placeholder],
+    textarea[placeholder] {
+      @content;
+    }
+
+    ::-moz-placeholder {
+      @content;
+    }
+
+    ::-webkit-input-placeholder {
+      @content;
+    }
+
   }
 }
 

--- a/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
+++ b/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
@@ -203,7 +203,7 @@
       @content;
     }
 
-    ::-moz-placeholder {
+    &::-moz-placeholder {
       @content;
     }
 


### PR DESCRIPTION
Previously, the mixin had to be used within a declaration. No more.