### PR TITLE
add three mixins to fine_mixins for fancy text underlines

### DIFF
--- a/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
+++ b/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
@@ -18,6 +18,96 @@
   list-style: none;
 }
 
+// Create iOS style text underlines
+// Comes in one mixin containing two additional mixins
+// each nested mixin depends on function/keyframe helper
+  // | underline-link
+    // |- underline-link-shadow
+    //  |- function: skew-it
+    // |- underline-transition
+    //  |- keyframe: underline-width
+// @include underline-link(white, black);
+// @include underline-link(white, black, false);
+
+@mixin underline-link-shadow($color) {
+  text-shadow:
+  skew-it(1) 0 $color, skew-it(-1) 0 $color,
+  0 skew-it(1) $color, 0 skew-it(-1) $color,
+  skew-it(2) 0 $color, skew-it(-2) 0 $color,
+  skew-it(3) 0 $color, skew-it(-3) 0 $color,
+  skew-it(4) 0 $color, skew-it(-4) 0 $color,
+  skew-it(5) 0 $color, skew-it(-5) 0 $color;
+}
+  @function skew-it($iteration) {
+    @return ($iteration * 0.03) * 1em;
+  }
+
+@mixin underline-link($background-color, $color, $transition: true) {
+  background-image: linear-gradient($background-color, $background-color), linear-gradient($background-color, $background-color), linear-gradient($color, $color);
+  background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+  background-repeat: no-repeat, no-repeat, repeat-x;
+  background-position: 0% 90%, 100% 90%, 0% 90%;
+  color: $color;
+  text-decoration: none;
+  @include underline-link-shadow($background-color);
+
+  @if $transition == true {
+    @include underline-transition($background-color);
+  }
+
+  &::selection {
+    @include underline-link-shadow($c-spec-white);
+    background: $c-spec-white;
+  }
+
+  &::-moz-selection {
+    @include underline-link-shadow($background-color);
+    background: $background-color;
+  }
+
+  &:before, &:after, *, *:before, *:after {
+    text-shadow: none
+  }
+
+  &:visited {
+    color: $color
+  }
+}
+
+@mixin underline-transition($background-color) {
+  position:relative;
+  display:inline-block;
+  z-index: 1;
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    width: 50%;
+    height: 0.25em;
+    bottom: 0;
+    background: $background-color;
+    z-index: -1;
+  }
+
+  &:after {
+    right: 0;
+  }
+
+  &:before {
+    left: 0;
+  }
+
+  &:hover {
+    &:before, &:after {
+      animation: underline-width 200ms cubic-bezier(.01,.99,.9,1) forwards;
+    }
+  }
+}
+  @keyframes underline-width {
+    0% { width: 50%; }
+    100% { width: 0%; }
+  }
+
+
 // Make a triangle (taken from Bourbon)
 @mixin triangle($direction: top, $color: $c-black, $size: 30px, $shadow: false) {
   position: relative;
@@ -189,6 +279,7 @@
         + "Please make sure it is defined in `$breakpoints` map.";
   }
 }
+
 
 // Style placeholder text at the root level or on an element
 @mixin placeholder {

--- a/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
+++ b/source/stylesheets/globals/imports/finescss/_fine_mixins.scss
@@ -18,38 +18,41 @@
   list-style: none;
 }
 
+// eager.io/blog/smarter-link-underlines/
+// Rewritten in SCSS from Stylus
 // Create iOS style text underlines
 // Comes in one mixin containing two additional mixins
 // each nested mixin depends on function/keyframe helper
-  // | underline-link
-    // |- underline-link-shadow
-    //  |- function: skew-it
-    // |- underline-transition
-    //  |- keyframe: underline-width
 // @include underline-link(white, black);
 // @include underline-link(white, black, false);
 
 @mixin underline-link-shadow($color) {
   text-shadow:
-  skew-it(1) 0 $color, skew-it(-1) 0 $color,
-  0 skew-it(1) $color, 0 skew-it(-1) $color,
-  skew-it(2) 0 $color, skew-it(-2) 0 $color,
-  skew-it(3) 0 $color, skew-it(-3) 0 $color,
-  skew-it(4) 0 $color, skew-it(-4) 0 $color,
-  skew-it(5) 0 $color, skew-it(-5) 0 $color;
+    skew-it(1) 0 $color,
+    skew-it(-1) 0 $color,
+    0 skew-it(1) $color,
+    0 skew-it(-1) $color,
+    skew-it(2) 0 $color,
+    skew-it(-2) 0 $color,
+    skew-it(3) 0 $color,
+    skew-it(-3) 0 $color,
+    skew-it(4) 0 $color,
+    skew-it(-4) 0 $color,
+    skew-it(5) 0 $color,
+    skew-it(-5) 0 $color;
 }
   @function skew-it($iteration) {
     @return ($iteration * 0.03) * 1em;
   }
 
 @mixin underline-link($background-color, $color, $transition: true) {
+  @include underline-link-shadow($background-color);
   background-image: linear-gradient($background-color, $background-color), linear-gradient($background-color, $background-color), linear-gradient($color, $color);
   background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
   background-repeat: no-repeat, no-repeat, repeat-x;
   background-position: 0% 90%, 100% 90%, 0% 90%;
   color: $color;
   text-decoration: none;
-  @include underline-link-shadow($background-color);
 
   @if $transition == true {
     @include underline-transition($background-color);
@@ -65,7 +68,11 @@
     background: $background-color;
   }
 
-  &:before, &:after, *, *:before, *:after {
+  &:before,
+  &:after,
+  *,
+  *:before,
+  *:after {
     text-shadow: none
   }
 
@@ -78,7 +85,8 @@
   position:relative;
   display:inline-block;
   z-index: 1;
-  &:before, &:after {
+  &:before,
+  &:after {
     content: '';
     position: absolute;
     width: 50%;
@@ -97,7 +105,8 @@
   }
 
   &:hover {
-    &:before, &:after {
+    &:before,
+    &:after {
       animation: underline-width 200ms cubic-bezier(.01,.99,.9,1) forwards;
     }
   }


### PR DESCRIPTION
I pulled this code from https://eager.io/blog/smarter-link-underlines/ & converted it to Sass, introduced the transition using some pseudo selectors and a keyframe, DRYd out the Sass a little with a helper function.