### PR TITLE
add query_order.scss to force sprocket media query combiner order

### DIFF
--- a/source/stylesheets/base.scss
+++ b/source/stylesheets/base.scss
@@ -8,6 +8,7 @@
 
 // Globals
 @import
+  'globals/query_order',
   'globals/tags',
   'globals/utilities',
   'globals/typography'

--- a/source/stylesheets/globals/_query_order.scss
+++ b/source/stylesheets/globals/_query_order.scss
@@ -1,0 +1,25 @@
+//////////////////////////////
+// Query Order
+//////////////////////////////
+
+// Used to force Sprockets Media Query Combiner to combine in the correct order
+
+// Min-width Queries
+@include bp(small) { /* small */ }
+@include bp(medium) { /* medium */ }
+@include bp(medium-only) { /* medium only */ }
+@include bp(medium-portrait) { /* medium portrait */ }
+@include bp(large) { /* large */ }
+@include bp(x-large) { /* x-large */ }
+
+// Max width queries need to come after min-width, and in reverse order
+@include bp(large-down) { /* large down */ }
+@include bp(medium-down) { /* medium down */ }
+@include bp(small-down) { /* small down */ }
+
+// Other Queries
+@include bp(print) { /* print */ }
+@include bp(screen) { /* screen */ }
+@include bp(retina) { /* retina */ }
+@include bp(portrait) { /* portrait */ }
+@include bp(landscape) { /* landscape */ }


### PR DESCRIPTION
Sprockets Media Query Combiner orders media queries on a first-come, first-served basis. We fool it into the correct order by using CSS comments and placing this file before we declare any real media queries.